### PR TITLE
Halt on 500 level errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "rand",
  "reqwest",
  "serde",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ oxide-api = { git = "http://github.com/oxidecomputer/oxide.rs.git", branch = "ma
 rand = "0.8.5"
 reqwest = "0.11.18"
 serde = { version = "1.0.163", features = ["derive"] }
+thiserror = "1.0.49"
 tokio = { version = "1.28.2", features = ["full"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 toml = "0.7.4"

--- a/src/actor/disk.rs
+++ b/src/actor/disk.rs
@@ -1,6 +1,5 @@
 //! An antagonist that exercises disk lifecycle commands (create, delete).
 
-use anyhow::Context;
 use async_trait::async_trait;
 use core::result::Result;
 use oxide_api::types::BlockSize;
@@ -163,8 +162,10 @@ impl DiskActor {
             }
         };
 
+        // `new` returns an error if the iterator is empty, if any weight is <
+        // 0, or if its total value is 0.
         let dist = rand::distributions::WeightedIndex::new(weights)
-            .context("generating disk action weights")?;
+            .unwrap();
         let mut rng = rand::thread_rng();
         Ok(actions[dist.sample(&mut rng)])
     }

--- a/src/actor/disk.rs
+++ b/src/actor/disk.rs
@@ -178,7 +178,7 @@ impl super::Antagonist for DiskActor {
         let state = match self.get_disk_state().await? {
             None => {
                 info!("disk doesn't exist, will try to create it");
-                return self.create_disk().await.map_err(|e| e.into());
+                return self.create_disk().await.map_err(Into::into);
             }
             Some(state) => {
                 trace!(?state, "got disk state");
@@ -198,6 +198,6 @@ impl super::Antagonist for DiskActor {
 
         sleep_random_ms(100).await;
 
-        result.map_err(|e| e.into())
+        result.map_err(Into::into)
     }
 }

--- a/src/actor/instance.rs
+++ b/src/actor/instance.rs
@@ -246,7 +246,7 @@ impl super::Antagonist for InstanceActor {
         let state = match self.get_instance_state().await? {
             None => {
                 info!("instance doesn't exist, will try to create it");
-                return self.create_instance().await.map_err(|e| e.into());
+                return self.create_instance().await.map_err(Into::into);
             }
             Some(state) => {
                 trace!(?state, "got instance state");
@@ -268,6 +268,6 @@ impl super::Antagonist for InstanceActor {
 
         sleep_random_ms(100).await;
 
-        result.map_err(|e| e.into())
+        result.map_err(Into::into)
     }
 }

--- a/src/actor/instance.rs
+++ b/src/actor/instance.rs
@@ -1,7 +1,6 @@
 //! An antagonist that exercises instance lifecycle commands (create, start,
 //! stop, destroy).
 
-use anyhow::Context;
 use async_trait::async_trait;
 use core::result::Result;
 use oxide_api::{types::InstanceState, ClientInstancesExt};
@@ -231,8 +230,10 @@ impl InstanceActor {
             ),
         };
 
+        // `new` returns an error if the iterator is empty, if any weight is <
+        // 0, or if its total value is 0.
         let dist = rand::distributions::WeightedIndex::new(weights)
-            .context("generating instance action weights")?;
+            .unwrap();
         let mut rng = rand::thread_rng();
         Ok(actions[dist.sample(&mut rng)])
     }

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -25,6 +25,9 @@ pub enum ActorKind {
 
 /// An individual actor task.
 pub struct Actor {
+    /// The actor's name
+    name: String,
+
     /// The tracing span to use for actions taken by this actor.
     span: tracing::Span,
 
@@ -137,7 +140,12 @@ impl Actor {
             .instrument(span.clone()),
         );
 
-        Ok((Self { span, task, pause_tx, paused_rx, halt_tx }, error_rx))
+        Ok((Self { name, span, task, pause_tx, paused_rx, halt_tx }, error_rx))
+    }
+
+    /// Return this actor's name
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Directs this actor to pause and waits for it to report that it has done

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -49,11 +49,14 @@ pub struct Actor {
 
 #[derive(thiserror::Error, Debug)]
 pub enum AntagonistError {
-    #[error("anyhow error")]
-    AnyhowError(#[from] anyhow::Error),
+    #[error("invalid actor state")]
+    InvalidState(String),
 
     #[error("oxide api error")]
     ApiError(#[from] OxideApiError),
+
+    #[error("antagonist {name} disconnected its error channel")]
+    DisconnectedErrorChannel { name: String },
 }
 
 /// A trait implemented by each kind of antagonist actor.

--- a/src/actor/snapshot.rs
+++ b/src/actor/snapshot.rs
@@ -264,7 +264,7 @@ impl super::Antagonist for SnapshotActor {
         let state = match self.get_snapshot_state().await? {
             None => {
                 info!("snapshot doesn't exist, will try to create it");
-                return self.create_snapshot().await.map_err(|e| e.into());
+                return self.create_snapshot().await.map_err(Into::into);
             }
             Some(state) => {
                 trace!(?state, "got snapshot state");
@@ -284,6 +284,6 @@ impl super::Antagonist for SnapshotActor {
 
         sleep_random_ms(100).await;
 
-        result.map_err(|e| e.into())
+        result.map_err(Into::into)
     }
 }

--- a/src/actor/snapshot.rs
+++ b/src/actor/snapshot.rs
@@ -1,6 +1,5 @@
 //! An antagonist that exercises snapshot lifecycle commands (create, delete).
 
-use anyhow::Context;
 use async_trait::async_trait;
 use core::result::Result;
 use oxide_api::types::BlockSize;
@@ -246,8 +245,10 @@ impl SnapshotActor {
             }
         };
 
+        // `new` returns an error if the iterator is empty, if any weight is <
+        // 0, or if its total value is 0.
         let dist = rand::distributions::WeightedIndex::new(weights)
-            .context("generating snapshot action weights")?;
+            .unwrap();
         let mut rng = rand::thread_rng();
         Ok(actions[dist.sample(&mut rng)])
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,4 +46,8 @@ pub struct Config {
     /// environment variable.
     #[arg(long)]
     pub hosts_toml_dir: Option<PathBuf>,
+
+    /// Halt omicron-stress if a 500 series error was seen
+    #[arg(long)]
+    pub server_errors_fatal: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,11 +161,11 @@ async fn main() -> Result<()> {
                     }
 
                     None => {
-                        let e = anyhow::anyhow!(
-                            "the {name} antagonist disconnected its error channel!"
-                        )
-                        .into();
-                        let _ = error_tx.send(e).await;
+                        let _ = error_tx
+                            .send(AntagonistError::DisconnectedErrorChannel {
+                                name,
+                            })
+                            .await;
                         break;
                     }
                 }
@@ -197,8 +197,9 @@ async fn main() -> Result<()> {
                                 }
                             }
 
-                            AntagonistError::AnyhowError(_) => {
-                                error!("actor error: {:?}", err);
+                            AntagonistError::InvalidState(_)
+                            | AntagonistError::DisconnectedErrorChannel { .. } => {
+                                error!("{err}");
                                 break;
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,8 +108,8 @@ async fn main() -> Result<()> {
                 }),
             )?;
 
+            error_channels.push((actor.name().to_string(), error_ch));
             actors.push(actor);
-            error_channels.push(error_ch);
         }
     }
 
@@ -123,8 +123,8 @@ async fn main() -> Result<()> {
                 }),
             )?;
 
+            error_channels.push((actor.name().to_string(), error_ch));
             actors.push(actor);
-            error_channels.push(error_ch);
         }
     }
 
@@ -143,15 +143,15 @@ async fn main() -> Result<()> {
                 }),
             )?;
 
+            error_channels.push((actor.name().to_string(), error_ch));
             actors.push(actor);
-            error_channels.push(error_ch);
         }
     }
 
     let (error_tx, mut error_rx) =
         tokio::sync::mpsc::channel::<AntagonistError>(1);
 
-    for mut error_ch in error_channels {
+    for (name, mut error_ch) in error_channels {
         let error_tx = error_tx.clone();
         tokio::spawn(async move {
             loop {
@@ -162,7 +162,7 @@ async fn main() -> Result<()> {
 
                     None => {
                         let e = anyhow::anyhow!(
-                            "an antagonist disconnected its error channel!"
+                            "the {name} antagonist disconnected its error channel!"
                         )
                         .into();
                         let _ = error_tx.send(e).await;


### PR DESCRIPTION
If a 500 level error is seen, halt omicron-stress if `--server-errors-fatal` is provided.

If an antagonist sees an error, it should emit a `warn` message: later, when collecting the errors, if an error is considered fatal it should be emit in an `error` message. This will allow easier skimming of the log output.