### PR TITLE
Migrate to credentials.toml for auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ in order):
 The runner will then try to obtain a login token from the following sources
 (again evaluated in order):
 
-- A `hosts.toml` file stored in one of the following locations:
+- A `credentials.toml` or the deprecated `hosts.toml` file stored in one of the following locations:
+  - The value of the `--credentials-toml-dir` command line option
   - The value of the `--hosts-toml-dir` command line option
   - `$HOME/.config/oxide`
 - The value of the `OXIDE_TOKEN` environment variable

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 
 /// The contents of an Oxide CLI `hosts.toml` file.
 #[derive(Debug, Deserialize, Serialize)]
@@ -22,11 +22,87 @@ struct Host {
     token: String,
 }
 
-/// Reads the contents of a hosts.toml file located in `dir`.
-fn read_hosts_toml(mut dir: PathBuf) -> Result<Hosts> {
-    dir.push("hosts.toml");
-    let hosts = std::fs::read_to_string(dir)?;
-    Ok(toml::from_str(&hosts)?)
+/// The contents of an Oxide CLI `credentials.toml` file.
+#[derive(Debug, Deserialize, Serialize)]
+struct Credentials {
+    /// A map from host names to per-host token and user information.
+    profile: HashMap<String, Credential>,
+}
+
+/// The contents of an Oxide CLI `credentials.toml` file.
+#[derive(Debug, Deserialize, Serialize)]
+struct Credential {
+    /// The ID of the user session for this entry.
+    user: String,
+
+    /// The URL of the host for this entry.
+    host: String,
+
+    /// The authentication token associated with this entry's session.
+    token: String,
+}
+
+/// An abstraction over `credentials.toml` and `hosts.toml` files.
+struct LoginConfig {
+    dir: PathBuf,
+}
+
+impl LoginConfig {
+    /// Checks whether `credentials.toml` or `hosts.toml` exist.
+    pub fn exists(&self) -> bool {
+        let creds = self.dir.clone().join("credentials.toml");
+        let hosts = self.dir.clone().join("hosts.toml");
+
+        creds.exists() || hosts.exists()
+    }
+
+    /// Read `credentials.toml` in, falling back to `hosts.toml if not present.
+    pub fn read_config(&self) -> Result<Hosts> {
+        let hosts = self.read_credentials_toml()?;
+        if let Some(hosts) = hosts {
+            return Ok(hosts);
+        }
+        self.read_hosts_toml()
+    }
+
+    /// The name of the config file being used for credentials.
+    pub fn file_name(&self) -> &str {
+        let creds = self.dir.clone().join("credentials.toml");
+        let hosts = self.dir.clone().join("hosts.toml");
+        match (creds.exists(), hosts.exists()) {
+            (true, _) => "credentials.toml",
+            (_, true) => "hosts.toml",
+            (false, false) => "no config found",
+        }
+    }
+
+    /// Reads the contents of a hosts.toml file located in `dir`.
+    fn read_hosts_toml(&self) -> Result<Hosts> {
+        let dir = self.dir.join("hosts.toml");
+        let hosts = std::fs::read_to_string(dir)?;
+
+        warn!("hosts.toml is deprecated. Please migrate to credentials.toml");
+        Ok(toml::from_str(&hosts)?)
+    }
+
+    /// Reads the contents of a `credentials.toml` file located in `dir`.
+    fn read_credentials_toml(&self) -> Result<Option<Hosts>> {
+        let dir = self.dir.join("credentials.toml");
+        if !dir.exists() {
+            return Ok(None);
+        }
+        let credentials_content = std::fs::read_to_string(dir)?;
+        let creds: Credentials = toml::from_str(&credentials_content)?;
+
+        let mut hosts = HashMap::new();
+
+        for cred in creds.profile.into_values() {
+            hosts
+                .insert(cred.host, Host { user: cred.user, token: cred.token });
+        }
+
+        Ok(Some(Hosts { hosts }))
+    }
 }
 
 /// Gets an Oxide SDK client. See the doc commens in `[crate::config::Config]`
@@ -40,10 +116,17 @@ pub fn get_client(config: &crate::config::Config) -> Result<oxide::Client> {
     };
     info!(%host, "Nexus URI");
 
-    // If the config containins a directory to search for `hosts.toml`, look
+    let config_dir =
+        match (&config.credentials_toml_dir, &config.hosts_toml_dir) {
+            (Some(creds), _) => Some(creds),
+            (_, Some(hosts)) => Some(hosts),
+            _ => None,
+        };
+
+    // If the config containins a directory to search for login credentials, look
     // there. Otherwise, try to get the current user's home directory and
     // search in its `.config/oxide` subdirectory.
-    let hosts_toml_dir = if let Some(dir) = &config.hosts_toml_dir {
+    let hosts_toml_dir = if let Some(dir) = config_dir {
         Some(dir.clone())
     } else if let Some(mut path) = dirs::home_dir() {
         path.push(".config/oxide");
@@ -52,33 +135,29 @@ pub fn get_client(config: &crate::config::Config) -> Result<oxide::Client> {
         None
     };
 
-    // Attempt to read `hosts.toml` and extract a token from it. If this fails
-    // for any reason (`hosts.toml` not found or malformed, or no search path
+    // Attempt to read credentials config and extract a token from it. If this fails
+    // for any reason (`credentials/hosts.toml` not found or malformed, or no search path
     // was present), fall back to the OXIDE_TOKEN variable.
-    let token = if let Some(hosts_toml_dir) = hosts_toml_dir {
-        let hosts_toml = {
-            let mut hosts_toml = hosts_toml_dir.clone();
-            hosts_toml.push("hosts.toml");
-            hosts_toml
-        };
+    let token = if let Some(creds_toml_dir) = hosts_toml_dir {
+        let login_config = LoginConfig { dir: creds_toml_dir.clone() };
 
-        if hosts_toml.exists() {
-            info!("reading hosts.toml from {}", hosts_toml_dir.display());
-            let hosts = read_hosts_toml(hosts_toml_dir)?;
-            info!("attempting to read token from hosts.toml");
+        if login_config.exists() {
+            info!("reading credentials from {}", creds_toml_dir.display());
+            let hosts = login_config.read_config()?;
+            info!("attempting to read token from {}", login_config.file_name());
             match hosts.hosts.get(&host) {
                 Some(entry) => Some(entry.token.clone()),
                 None => {
-                    info!("no token found in hosts.toml");
+                    info!("no token found");
                     None
                 }
             }
         } else {
-            info!("hosts.toml file does not exist");
+            info!("could not find credentials.toml or hosts.toml file");
             None
         }
     } else {
-        info!("no search path for hosts.toml");
+        info!("no search path for login credentials");
         None
     };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,13 +23,14 @@ struct Host {
 }
 
 /// The contents of an Oxide CLI `credentials.toml` file.
+/// key: profile_name, value: Credential { host, user, token }
 #[derive(Debug, Deserialize, Serialize)]
 struct Credentials {
     /// A map from host names to per-host token and user information.
     profile: HashMap<String, Credential>,
 }
 
-/// The contents of an Oxide CLI `credentials.toml` file.
+/// An individual entry in `credentials.toml`.
 #[derive(Debug, Deserialize, Serialize)]
 struct Credential {
     /// The ID of the user session for this entry.
@@ -147,7 +148,7 @@ pub fn get_client(config: &crate::config::Config) -> Result<oxide::Client> {
     };
 
     // Attempt to read credentials config and extract a token from it. If this fails
-    // for any reason (`credentials/hosts.toml` not found or malformed, or no search path
+    // for any reason (`credentials.toml/hosts.toml` not found or malformed, or no search path
     // was present), fall back to the OXIDE_TOKEN variable.
     let token = if let Some(creds_toml_dir) = creds_toml_dir {
         if let Some(login_config) = LoginConfig::try_new(creds_toml_dir.clone())

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,11 @@ pub struct Config {
     #[arg(long)]
     pub hosts_toml_dir: Option<PathBuf>,
 
+    /// The directory in which to search for a `credentials.toml` file from which to
+    /// read an authentication token to supply to Nexus. If not set, defaults to
+    /// $HOME_DIRECTORY/.config/oxide. If no token is found with the
+    /// `hosts.toml` method, falls back to the value of the OXIDE_TOKEN
+    /// environment variable.
     #[arg(long)]
     pub credentials_toml_dir: Option<PathBuf>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,9 @@ pub struct Config {
     #[arg(long)]
     pub hosts_toml_dir: Option<PathBuf>,
 
+    #[arg(long)]
+    pub credentials_toml_dir: Option<PathBuf>,
+
     /// Halt omicron-stress if a 500 series error was seen
     #[arg(long)]
     pub server_errors_fatal: bool,


### PR DESCRIPTION
With Release 9 we removed support for `hosts.toml` files in `oxide.rs`.

Add support for the new `credentials.toml` format and warn users that `hosts.toml` is deprecated.