### PR TITLE
Make invalid states (more) representable

### DIFF
--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -49,10 +49,10 @@ pub struct Actor {
 
 #[derive(thiserror::Error, Debug)]
 pub enum AntagonistError {
-    #[error("invalid actor state")]
+    #[error("invalid actor state: {0}")]
     InvalidState(String),
 
-    #[error("oxide api error")]
+    #[error("oxide api error: {0}")]
     ApiError(#[from] OxideApiError),
 
     #[error("antagonist {name} disconnected its error channel")]


### PR DESCRIPTION
Currently, the `AntagonistError` type has some errors that wrap other
values, but don't format those values when displayed. This is kind of
unfortunate. For example:

```
2024-10-23T21:01:34.795972Z ERROR omicron_stress: 202: invalid actor state
2024-10-23T21:01:34.796049Z  INFO omicron_stress: 218: Halting actors
```

Seeing this in my logs felt kind of painful, because it's like, "okay,
what was the invalid state?" and there's no way to find out what it was.
It turns out that there's a string that's in there which says what the
invalid state was, but it didn't get formatted in the `Display` impl,
and now the process has exited, so which invalid state occurred has been
permanently lost to the sands of time.

After this change, it now looks like this:

```
2024-10-23T21:25:17.983062Z ERROR omicron_stress: 202: invalid actor state: instance inst1 unexpectedly in state Failed
2024-10-23T21:25:17.983160Z  INFO omicron_stress: 218: Halting actors
```

If you compare this with the output from before, you will notice that I
have made invalid states representable. In this case, that's actually a
good thing.